### PR TITLE
Install correct MS ODBC package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update && apt-get install -y --no-install-recommends apt-transport-https
 
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-&& curl https://packages.microsoft.com/config/debian/8/prod.list | tee -a /etc/apt/sources.list.d/mssql-release.list \
+&& curl https://packages.microsoft.com/config/debian/9/prod.list | tee -a /etc/apt/sources.list.d/mssql-release.list \
 && apt-get update \
-&& ACCEPT_EULA=Y apt-get install msodbcsql -y \
+&& ACCEPT_EULA=Y apt-get install msodbcsql17 -y \
 && apt-get install unixodbc-dev -y
 
 # --- APP INSTALL ---


### PR DESCRIPTION
From [Microsoft site](https://docs.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server)
> If you installed the v17 msodbcsql package that was briefly available, you should remove it before installing the msodbcsql17 package. This will avoid conflicts. The msodbcsql17 package can be installed side by side with the msodbcsql v13 package.